### PR TITLE
Use forground colors on borders of floating windows

### DIFF
--- a/lua/pywal/config.lua
+++ b/lua/pywal/config.lua
@@ -22,7 +22,7 @@ M.highlights_base = function (colors)
     Folded = { fg = colors.color4, bg = colors.background },
     FoldColumn = { fg = colors.color4, bg = colors.background },
     LineNr = { fg = colors.color9, bg = colors.background },
-    FloatBorder = { fg = colors.background, bg = colors.background },
+    FloatBorder = { fg = colors.foreground, bg = colors.background },
     Whitespace = { fg = colors.color1 },
     VertSplit = { fg = colors.background, bg = colors.color1 },
     CursorLine = { bg = colors.background },
@@ -227,7 +227,7 @@ M.highlights_base = function (colors)
 
     -- LspSaga
     LspFloatWinNormal = { bg = colors.background },
-    LspFloatWinBorder = { fg = colors.background },
+    LspFloatWinBorder = { fg = colors.foreground },
     LspSagaBorderTitle = { fg = colors.color7 },
     LspSagaHoverBorder = { fg = colors.color7 },
     LspSagaRenameBorder = { fg = colors.color4 },


### PR DESCRIPTION
Floating windows used the pywal background color for both the background and foreground, making borders invisible. This sets it to use the foreground color. 